### PR TITLE
fix(vless): improve domain address parsing robustness

### DIFF
--- a/crates/dae-proxy/src/vless/handler.rs
+++ b/crates/dae-proxy/src/vless/handler.rs
@@ -807,6 +807,14 @@ impl VlessHandler {
                     ));
                 }
                 let domain_len = buf[5] as usize;
+                // Reject empty domains (domain_len == 0) for security
+                // Empty domains could indicate malformed packets or injection attempts
+                if domain_len == 0 {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "empty domain not allowed",
+                    ));
+                }
                 if buf.len() < 6 + domain_len + 2 {
                     return Err(std::io::Error::new(
                         std::io::ErrorKind::InvalidData,

--- a/crates/dae-proxy/src/vless/protocol.rs
+++ b/crates/dae-proxy/src/vless/protocol.rs
@@ -12,6 +12,10 @@ pub const VLESS_HEADER_MIN_SIZE: usize = 38; // v1 + uuid(16) + ver(1) + cmd(1) 
 #[allow(dead_code)]
 pub const VLESS_REQUEST_HEADER_SIZE: usize = 22; // port(4) + atyp(1) + addr + iv(16)
 
+/// Maximum domain name length per VLESS protocol (255 bytes as u8)
+/// This is the protocol limit for the domain length field.
+const MAX_DOMAIN_LEN: usize = 255;
+
 /// VLESS command types
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum VlessCommand {
@@ -104,6 +108,10 @@ impl VlessTargetAddress {
                     return None;
                 }
                 let domain_len = payload[1] as usize;
+                // Reject empty domains (domain_len == 0) for security
+                if domain_len == 0 {
+                    return None;
+                }
                 if payload.len() < 4 + domain_len {
                     return None;
                 }
@@ -153,6 +161,14 @@ impl VlessTargetAddress {
                 bytes
             }
             VlessTargetAddress::Domain(domain, _) => {
+                // Validate domain length before encoding to prevent truncation
+                // VLESS protocol uses u8 for domain length field (max 255)
+                if domain.len() > MAX_DOMAIN_LEN {
+                    // Domain too long - cannot encode safely
+                    // Return a Vec that will cause parsing to fail downstream
+                    // This prevents silent truncation which would corrupt data
+                    return vec![0x02, 0x00]; // Invalid encoding - empty domain
+                }
                 let mut bytes = vec![0x02, domain.len() as u8];
                 bytes.extend_from_slice(domain.as_bytes());
                 bytes


### PR DESCRIPTION
## Summary
Improves VLESS domain address parsing robustness:

### Changes
1. **Empty domain rejection** in `parse_from_bytes()` - prevents malformed packets
2. **Empty domain rejection** in `handler.rs::parse_target_address()` - with clear error message
3. **Overflow protection** in `to_bytes()` - prevents silent truncation for domains > 255 chars

### Testing
- All 623 tests pass
- Build verification successful